### PR TITLE
add AbsorbCollateral to IComet

### DIFF
--- a/src/legend-scripts/src/interfaces/IComet.sol
+++ b/src/legend-scripts/src/interfaces/IComet.sol
@@ -2,7 +2,13 @@
 pragma solidity 0.8.23;
 
 interface IComet {
-    event AbsorbCollateral(address indexed absorber, address indexed borrower, address indexed asset, uint collateralAbsorbed, uint usdValue);
+    event AbsorbCollateral(
+        address indexed absorber,
+        address indexed borrower,
+        address indexed asset,
+        uint256 collateralAbsorbed,
+        uint256 usdValue
+    );
 
     function getAssetInfo(uint8 i) external view returns (AssetInfo memory);
 

--- a/src/legend-scripts/src/interfaces/IComet.sol
+++ b/src/legend-scripts/src/interfaces/IComet.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.23;
 
 interface IComet {
+    event AbsorbCollateral(address indexed absorber, address indexed borrower, address indexed asset, uint collateralAbsorbed, uint usdValue);
+
     function getAssetInfo(uint8 i) external view returns (AssetInfo memory);
 
     function baseToken() external view returns (address);

--- a/test/quark-core-scripts/interfaces/IComet.sol
+++ b/test/quark-core-scripts/interfaces/IComet.sol
@@ -2,7 +2,13 @@
 pragma solidity 0.8.23;
 
 interface IComet {
-    event AbsorbCollateral(address indexed absorber, address indexed borrower, address indexed asset, uint collateralAbsorbed, uint usdValue);
+    event AbsorbCollateral(
+        address indexed absorber,
+        address indexed borrower,
+        address indexed asset,
+        uint256 collateralAbsorbed,
+        uint256 usdValue
+    );
 
     function getAssetInfo(uint8 i) external view returns (AssetInfo memory);
 

--- a/test/quark-core-scripts/interfaces/IComet.sol
+++ b/test/quark-core-scripts/interfaces/IComet.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.23;
 
 interface IComet {
+    event AbsorbCollateral(address indexed absorber, address indexed borrower, address indexed asset, uint collateralAbsorbed, uint usdValue);
+
     function getAssetInfo(uint8 i) external view returns (AssetInfo memory);
 
     function baseToken() external view returns (address);


### PR DESCRIPTION
Related to: https://github.com/compound-finance/legend/pull/366

adding `AbsorbCollateral` to IComet.

We currently define `IComet` in two places; I believe the version in `/test` is actually the version that gets built when you call `forge build`, but I've updated it in both places for consistency.

From https://github.com/compound-finance/quark/pull/188 via @scott-silver 